### PR TITLE
Remove at most one leading space from comments

### DIFF
--- a/luadoc/parser.py
+++ b/luadoc/parser.py
@@ -246,7 +246,11 @@ class LuaDocParser:
 
     def _parse_comment(self, comment: str, ast_node: Node):
         if comment.startswith(self._start_symbol):
-            text = comment.lstrip(self._start_symbol + " ")
+            text = comment[len(self._start_symbol):]
+
+            if text.startswith(" "):
+                text = text[1:]
+
             parts = text.split(" ", 1)
             if parts:
                 if parts[0].startswith('@'):


### PR DESCRIPTION
Hi,

I want to use your sphinx-lua project and I noticed that currently *all* leading spaces are removed from each line.
This is not compatible with the significant indentation used in rst syntax. For example a multiline list would not be handled as expected:

```lua
--- Foo
--- * single line elements works as expected
--- * multi line elements
---   are supposed to be aligned with the previous lines
--- * but the leading spaces are removed by the parser
function foo()
    print("foo")
end
```

This PR simply change the line where the leading comment mark was removed to remove *at most* one leading space.
The problem was that the `lstrip` method takes a *list* of independent characters as an argument, not a fixed string.

Hopefully, this fix fits your vision for this project.